### PR TITLE
Cut 6.9 release of Racket docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,11 @@ language: ruby
 services: 
   - docker
 script: 
-  - docker build -t racket .
-  - docker run -it racket
+  - docker build -t ptrteixeira/racket:6.9 -t ptrteixeira/racket:latest .
+  - docker run -it ptrteixeira/racket
+after_success:
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker push ptrteixeira/racket:latest;
+    docker push ptrteixeira/racket:6.9;
+    fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM buildpack-deps:jessie-curl
 
-ENV RACKET_SHA1 e96dbe2ed47463ad075b98276b986e2703fb5c2d
+ENV RACKET_SHA1 6e5f06f0d0a6c13585f65ff0cf3dcc66f272372c
 
-RUN wget -qO /tmp/racket.sh https://mirror.racket-lang.org/installers/6.8/racket-6.8-x86_64-linux.sh && \
+RUN wget -qO /tmp/racket.sh https://mirror.racket-lang.org/installers/6.9/racket-6.9-x86_64-linux.sh && \
 /bin/sh /tmp/racket.sh >> /dev/null && \
 rm /tmp/racket.sh
 


### PR DESCRIPTION
Same as always, I guess, at least until they start releasing the image
to a different place. I'm about a month late on this.