### PR TITLE
Bump Racket release to 6.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM buildpack-deps:jessie-curl
 
-ENV RACKET_SHA1 91f047da4c0fe8da133c501f5e26b673a1eb4ed0 
+ENV RACKET_SHA1 78a6964df4e950606b9b7c14c08f2ad1ffe7a88c 
 
-RUN wget -qO /tmp/racket.sh https://mirror.racket-lang.org/installers/6.10.1/racket-6.10.1-x86_64-linux.sh && \
+RUN wget -qO /tmp/racket.sh https://mirror.racket-lang.org/installers/6.11/racket-6.11-x86_64-linux.sh && \
 /bin/sh /tmp/racket.sh >> /dev/null && \
 rm /tmp/racket.sh
 


### PR DESCRIPTION
Racket 6.11 was released this month - within the last couple
of days, I think, because I actually did check recently. In
any event, big new features!

- Refinement types / Dependent types in Typed Racket
- Serializable web formlets, if you write Racket web servers
- the `db` library supports Cassandra
- Also perf improvements to DrRacket, but I don't suggest running
  DrRacket out of a Docker container (in theory you can, though!)