### PR TITLE
Don't push from Travis to Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,5 @@ language: ruby
 services: 
   - docker
 script: 
-  - docker build -t ptrteixeira/racket:6.9 -t ptrteixeira/racket:latest .
+  - docker build -t ptrteixeira/racket:latest .
   - docker run -it ptrteixeira/racket
-after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
-    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    docker push ptrteixeira/racket:latest;
-    docker push ptrteixeira/racket:6.9;
-    fi


### PR DESCRIPTION
Clearly I haven't edited this in a while, which means that the Racket
6.9 image is (and has been, likely) f'ed up for a while. Oops. Anyways,
builds are currently done by Docker Cloud, and shouldn't also be done by
Travis.